### PR TITLE
Update Dockerfile to support PHP 7.4

### DIFF
--- a/.docker/php7.4-apache/Dockerfile
+++ b/.docker/php7.4-apache/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get install -y \
         libgmp-dev \
         # regex
         libonig-dev \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ \
     && docker-php-ext-install -j$(nproc) gd mbstring zip mysqli pdo_mysql gmp \
     && docker-php-ext-enable xdebug \
     && docker-php-ext-enable redis \


### PR DESCRIPTION
They removed the `dir` suffix at the end. According to https://github.com/docker-library/php/issues/912#issuecomment-559918036