### PR TITLE
Fix github action

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -50,3 +50,12 @@ jobs:
           DB_DATABASE: application
           DB_USERNAME: root
           DB_PASSWORD: secret
+
+      - name: Update github status
+        uses: Sibz/github-status-action@v1
+        with:
+          authToken: ${{secrets.GITHUB_TOKEN}}
+          context: 'PHPUnit'
+          description: 'Passed'
+          state: 'success'
+          sha: ${{github.event.pull_request.head.sha || github.sha}}


### PR DESCRIPTION
The PHPUnit action does not 'pass', that apparently changed in GH. This should pass the status (or not), so that we can block merges based on test results.