### PR TITLE
Feat: Disable forced spa url via ENV var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
 
+SPA_FORCE_URL=true
 SPA_URL=http://localhost:8080
 
 LOG_CHANNEL=stack

--- a/app/Http/Controllers/Api/Auth/Dispense.php
+++ b/app/Http/Controllers/Api/Auth/Dispense.php
@@ -80,7 +80,11 @@ final class Dispense
             null !== $request->headers->get('referer')) {
             $urlInfo = parse_url($request->headers->get('referer'));
             if (is_array($urlInfo) && isset($urlInfo['scheme']) && isset($urlInfo['host'])) {
-                $urlGenerator = new UrlGenerator($urlInfo['scheme'] . '://' . $urlInfo['host']);
+                if (isset($urlInfo['port'])) {
+                    $urlGenerator = new UrlGenerator("{$urlInfo['scheme']}://{$urlInfo['host']}:{$urlInfo['port']}");
+                } else {
+                    $urlGenerator = new UrlGenerator("{$urlInfo['scheme']}://{$urlInfo['host']}");
+                }
 
                 return $urlGenerator->to('auth/callback', [
                     'redirect_uri' => $request->input('redirect_uri'),

--- a/app/Http/Controllers/Api/Auth/Dispense.php
+++ b/app/Http/Controllers/Api/Auth/Dispense.php
@@ -10,7 +10,7 @@ use App\Contracts\Http\Responses\ResponseFactory;
 use App\Models\User;
 use App\Models\UserToken;
 use App\SPA\UrlGenerator;
-use Illuminate\Contracts\Translation\Translator;
+use Illuminate\Config\Repository;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
@@ -23,18 +23,18 @@ final class Dispense
 
     private LoginDispensary $dispensary;
 
-    private Translator $translator;
+    private Repository $config;
 
     public function __construct(
         ResponseFactory $responseFactory,
         UrlGenerator $urlGenerator,
         LoginDispensary $dispensary,
-        Translator $translator
+        Repository $config
     ) {
         $this->responseFactory = $responseFactory;
         $this->urlGenerator = $urlGenerator;
         $this->dispensary = $dispensary;
-        $this->translator = $translator;
+        $this->config = $config;
     }
 
     /**
@@ -43,9 +43,7 @@ final class Dispense
      */
     public function __invoke(Request $request): RedirectResponse
     {
-        $url = $this->urlGenerator->to('auth/callback', [
-            'redirect_uri' => $request->input('redirect_uri'),
-        ]);
+        $url = $this->createUrl($request);
 
         if (! $request->filled(['email', 'token'])) {
             return $this->responseFactory->redirectTo($url);
@@ -74,5 +72,24 @@ final class Dispense
         } catch (TokenExpiredException $exception) {
             return $this->responseFactory->redirectTo($url);
         }
+    }
+
+    private function createUrl(Request $request): string
+    {
+        if (false === $this->config->get('spa.force_url') &&
+            null !== $request->headers->get('referer')) {
+            $urlInfo = parse_url($request->headers->get('referer'));
+            if (is_array($urlInfo) && isset($urlInfo['scheme']) && isset($urlInfo['host'])) {
+                $urlGenerator = new UrlGenerator($urlInfo['scheme'] . '://' . $urlInfo['host']);
+
+                return $urlGenerator->to('auth/callback', [
+                    'redirect_uri' => $request->input('redirect_uri'),
+                ]);
+            }
+        }
+
+        return $this->urlGenerator->to('auth/callback', [
+            'redirect_uri' => $request->input('redirect_uri'),
+        ]);
     }
 }

--- a/config/spa.php
+++ b/config/spa.php
@@ -2,4 +2,5 @@
 
 return [
     'url' => env('SPA_URL', 'http://localhost:8080'),
+    'force_url' => env('SPA_FORCE_URL', true),
 ];

--- a/tests/Feature/Http/Api/Auth/DispenseTest.php
+++ b/tests/Feature/Http/Api/Auth/DispenseTest.php
@@ -8,6 +8,7 @@ use App\Auth\Dispensary\Repository;
 use App\Auth\LoginDispensary;
 use App\SPA\UrlGenerator;
 use Database\Factories\UserFactory;
+use Illuminate\Support\Facades\Config;
 use Tests\TestCase;
 use function bcrypt;
 use function parse_url;
@@ -19,14 +20,6 @@ use const PHP_URL_FRAGMENT;
  */
 final class DispenseTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->dispensary = $this->app->make(LoginDispensary::class);
-        $this->urlGenerator = $this->app->make(UrlGenerator::class);
-    }
-
     public function test()
     {
         $user = UserFactory::new()->createOne([
@@ -35,16 +28,44 @@ final class DispenseTest extends TestCase
 
         $token = $this->dispensary->dispense($user);
 
-        $response = $this->json('post', 'auth/dispense', [
-            'email' => $user->email,
-            'token' => $token,
-        ]);
+        $response = $this
+            ->withHeader('Referer', 'https://www.kingscode.nl/')
+            ->json('post', 'auth/dispense', [
+                'email' => $user->email,
+                'token' => $token,
+            ]);
 
         $response->isRedirect();
 
         $redirectUri = $response->headers->get('Location');
 
         $this->assertStringContainsString($this->urlGenerator->to('auth/callback'), $redirectUri);
+
+        $this->assertStringContainsString('token=', parse_url($redirectUri, PHP_URL_FRAGMENT));
+    }
+
+    public function testWithReferer()
+    {
+        Config::set('spa.force_url', false);
+
+        $user = UserFactory::new()->createOne([
+            'password' => bcrypt('kingscodedotnl'),
+        ]);
+
+        $token = $this->dispensary->dispense($user);
+
+        $response = $this
+            ->withHeader('Referer', 'https://www.kingscode.nl/team')
+            ->json('post', 'auth/dispense', [
+                'email' => $user->email,
+                'token' => $token,
+            ]);
+
+        $response->isRedirect();
+
+        $redirectUri = $response->headers->get('Location');
+
+        $this->assertStringContainsString('https://www.kingscode.nl/auth/callback', $redirectUri);
 
         $this->assertStringContainsString('token=', parse_url($redirectUri, PHP_URL_FRAGMENT));
     }
@@ -110,7 +131,7 @@ final class DispenseTest extends TestCase
             'password' => bcrypt('kingscodedotnl'),
         ]);
 
-        $token = $this->dispensary->dispense($user);
+        $this->dispensary->dispense($user);
 
         $response = $this->json('post', 'auth/dispense', [
             'email' => $user->email,
@@ -124,18 +145,34 @@ final class DispenseTest extends TestCase
 
     public function testRedirectsBackWhenEmailDoesntExists()
     {
-        $user = UserFactory::new()->createOne([
+        UserFactory::new()->createOne([
             'email'    => 'yoink@dadoink.nl',
             'password' => bcrypt('kingscodedotnl'),
         ]);
 
         $response = $this->json('post', 'auth/dispense', [
-            'email' => 'info@kingscode.nl',
+            'email' => 'testing@kingscode.nl',
             'token' => 'shizzlepizza',
         ]);
 
         $redirectUri = $response->headers->get('Location');
 
         $this->assertStringContainsString($this->urlGenerator->to('auth/callback'), $redirectUri);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('spa.force_url', true);
+        Config::set('spa.url', 'http://localhost:1337');
+        $this->dispensary = $this->app->make(LoginDispensary::class);
+        $this->urlGenerator = $this->app->make(UrlGenerator::class);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($this->dispensary, $this->urlGenerator);
+        parent::tearDown();
     }
 }

--- a/tests/Feature/Http/Api/Auth/DispenseTest.php
+++ b/tests/Feature/Http/Api/Auth/DispenseTest.php
@@ -70,6 +70,32 @@ final class DispenseTest extends TestCase
         $this->assertStringContainsString('token=', parse_url($redirectUri, PHP_URL_FRAGMENT));
     }
 
+    public function testWithRefererIncludingPort()
+    {
+        Config::set('spa.force_url', false);
+
+        $user = UserFactory::new()->createOne([
+            'password' => bcrypt('kingscodedotnl'),
+        ]);
+
+        $token = $this->dispensary->dispense($user);
+
+        $response = $this
+            ->withHeader('Referer', 'https://www.kingscode.nl:8080/team')
+            ->json('post', 'auth/dispense', [
+                'email' => $user->email,
+                'token' => $token,
+            ]);
+
+        $response->isRedirect();
+
+        $redirectUri = $response->headers->get('Location');
+
+        $this->assertStringContainsString('https://www.kingscode.nl:8080/auth/callback', $redirectUri);
+
+        $this->assertStringContainsString('token=', parse_url($redirectUri, PHP_URL_FRAGMENT));
+    }
+
     public function testWithRedirectUri()
     {
         $user = UserFactory::new()->createOne([


### PR DESCRIPTION
This PR adds functionality to disable the forced SPA url redirect. This is required for Google Firebase deployment with pull-request decoration, because the SPA url will be unique each deployment.

For 'classic' projects, this env var can always be left on `true` (default).